### PR TITLE
Restore imports and wire up root React component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,1 +1,26 @@
- 
+import React from 'react'
+import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import Game from './components/Game'
+import Header from './components/ui/header'
+import Footer from './components/ui/footer'
+import { SettingsProvider } from './contexts/settingscontext'
+import { WinStreakProvider } from './contexts/winstreakcontext'
+import { DuelProvider } from './contexts/duelcontext'
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <SettingsProvider>
+        <WinStreakProvider>
+          <DuelProvider>
+            <Header />
+            <Routes>
+              <Route path="/" element={<Game />} />
+            </Routes>
+            <Footer />
+          </DuelProvider>
+        </WinStreakProvider>
+      </SettingsProvider>
+    </BrowserRouter>
+  )
+}

--- a/src/components/ui/affiliatelinkbanner.tsx
+++ b/src/components/ui/affiliatelinkbanner.tsx
@@ -1,3 +1,6 @@
+import { FC, useEffect, useRef, useState } from 'react'
+import useAnalytics from '../../hooks/useanalytics'
+
 const srOnlyStyle: React.CSSProperties = {
   position: 'absolute',
   width: '1px',
@@ -10,7 +13,20 @@ const srOnlyStyle: React.CSSProperties = {
   border: 0,
 }
 
+interface AffiliateLinkBannerProps {
+  affiliateId: string
+}
+
+const styles = {
+  banner: 'affiliate-banner',
+  text: 'affiliate-banner-text',
+  controls: 'affiliate-banner-controls',
+  input: 'affiliate-banner-input',
+  button: 'affiliate-banner-button',
+}
+
 const AffiliateLinkBanner: FC<AffiliateLinkBannerProps> = ({ affiliateId }) => {
+  const { trackEvent } = useAnalytics()
   const [copied, setCopied] = useState(false)
   const timeoutRef = useRef<number>()
   const inputRef = useRef<HTMLInputElement>(null)

--- a/src/components/ui/cardtile.tsx
+++ b/src/components/ui/cardtile.tsx
@@ -1,13 +1,32 @@
-function useCardSelect(card: CardTileProps['card'], onSelect: CardTileProps['onSelect']) {
+import { memo, useCallback } from 'react'
+import classNames from 'classnames'
+import useAnalytics from '../../hooks/useanalytics'
+
+interface Card {
+  id: string
+  name: string
+  imageUrl: string
+  attack: number
+  defense: number
+  rarity?: string
+}
+
+interface CardTileProps {
+  card: Card
+  onSelect: (card: Card) => void
+}
+
+function useCardSelect(card: CardTileProps['card'], onSelect: CardTileProps['onSelect'], trackEvent: (e: string, d?: Record<string, unknown>) => void) {
   return useCallback(() => {
     onSelect(card)
     trackEvent('CardSelected', { cardId: card.id })
-  }, [card, onSelect])
+  }, [card, onSelect, trackEvent])
 }
 
 const CardTile: React.FC<CardTileProps> = ({ card, onSelect }) => {
+  const { trackEvent } = useAnalytics()
   const { id, name, imageUrl, attack, defense, rarity } = card
-  const handleSelect = useCardSelect(card, onSelect)
+  const handleSelect = useCardSelect(card, onSelect, trackEvent)
 
   return (
     <button
@@ -37,3 +56,4 @@ const CardTile: React.FC<CardTileProps> = ({ card, onSelect }) => {
 }
 
 export default memo(CardTile)
+

--- a/src/components/ui/footer.tsx
+++ b/src/components/ui/footer.tsx
@@ -1,4 +1,12 @@
-function Footer(): JSX.Element {
+import { FC, useCallback, useEffect, useState } from 'react'
+
+interface Toast {
+  message: string
+  type: 'success' | 'error' | 'info'
+  link?: string
+}
+
+const Footer: FC = () => {
   const [toast, setToast] = useState<Toast | null>(null);
 
   const showToast = useCallback((toast: Toast) => {

--- a/src/components/ui/header.tsx
+++ b/src/components/ui/header.tsx
@@ -1,3 +1,8 @@
+import { useCallback, useState } from 'react'
+import { Link } from 'react-router-dom'
+import useAnalytics from '../../hooks/useanalytics'
+import { useWinStreak } from '../../contexts/winstreakcontext'
+
 const Header: React.FC = () => {
   const [menuOpen, setMenuOpen] = useState(false)
   const winStreak = useWinStreak()

--- a/src/components/ui/interstitialadmanager.tsx
+++ b/src/components/ui/interstitialadmanager.tsx
@@ -1,4 +1,6 @@
-const AD_UNIT_PATH = process.env.REACT_APP_GPT_INTERSTITIAL_AD_UNIT_ID || '/1234567/default_interstitial';
+import { useEffect } from 'react'
+
+const AD_UNIT_PATH = process.env.REACT_APP_GPT_INTERSTITIAL_AD_UNIT_ID || '/1234567/default_interstitial'
 
 let interstitialSlot: googletag.Slot | null = null;
 let isAdLoaded = false;

--- a/src/components/ui/loadingspinner.tsx
+++ b/src/components/ui/loadingspinner.tsx
@@ -1,3 +1,11 @@
+import { FC, useId } from 'react'
+
+interface LoadingSpinnerProps {
+  size?: number
+  color?: string
+  label?: string
+}
+
 const LoadingSpinner: FC<LoadingSpinnerProps> = ({
   size = 40,
   color = '#3498db',

--- a/src/contexts/settingscontext.tsx
+++ b/src/contexts/settingscontext.tsx
@@ -1,3 +1,13 @@
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
+
 const SETTINGS_STORAGE_KEY = 'crookmon_quick_clash_settings'
 
 type Settings = {

--- a/src/contexts/winstreakcontext.tsx
+++ b/src/contexts/winstreakcontext.tsx
@@ -1,3 +1,11 @@
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from 'react'
+
 const WinStreakContext = createContext<WinStreakContextType | undefined>(undefined)
 
 const CURRENT_STREAK_KEY = 'winStreak.current'

--- a/src/hooks/useanalytics.ts
+++ b/src/hooks/useanalytics.ts
@@ -1,0 +1,10 @@
+import { useCallback } from 'react'
+import * as Analytics from '../services/analyticsservice'
+
+export default function useAnalytics() {
+  const trackEvent = useCallback((eventName: string, data?: Record<string, unknown>) => {
+    Analytics.logEvent(eventName, data)
+  }, [])
+
+  return { trackEvent }
+}


### PR DESCRIPTION
## Summary
- implement `App.tsx` with router and context providers
- add missing React imports to context files
- add analytics hook and wire components to it
- fix component files with missing imports

## Testing
- `npm test` *(fails: jest not found)*
- `npm run coverage` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68775f8f8414832bae53ad2d84b9bd05