### PR TITLE
Add fetch polyfill and document Node requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ npm install crookmon-game
 yarn add crookmon-game
 ```
 
+### Node Compatibility
+
+This library targets **Node.js 14+**. The analytics service relies on the
+`fetch` API. Node 18 and later include `fetch` natively. For Node 14 or 16,
+install a polyfill such as [`cross-fetch`](https://www.npmjs.com/package/cross-fetch).
+
 ---
 
 ## Quick Start

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   "dependencies": {
     "react": ">=18",
     "react-dom": ">=18",
-    "react-router-dom": "^6.8.0"
+    "react-router-dom": "^6.8.0",
+    "cross-fetch": "^3.1.8"
   },
   "devDependencies": {
     "@babel/core": "^7.28.0",

--- a/src/services/analyticsservice.ts
+++ b/src/services/analyticsservice.ts
@@ -1,3 +1,5 @@
+import fetch from 'cross-fetch'
+
 export interface AnalyticsEvent {
   eventName: string
   data?: Record<string, unknown>


### PR DESCRIPTION
## Summary
- add `cross-fetch` to dependencies
- import `cross-fetch` in `AnalyticsService`
- note Node.js version requirements and polyfill in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879bf7151dc832b91ea41196e92d3a8