### PR TITLE
Add type effectiveness import for damage calculator

### DIFF
--- a/src/core/engine/damagecalculator.js
+++ b/src/core/engine/damagecalculator.js
@@ -1,3 +1,5 @@
+import { getTypeEffectiveness } from '../data/types.js';
+
 function calculateCritical(attacker) {
   if (!attacker || !attacker.stats || typeof attacker.stats.speed !== 'number') {
     return { multiplier: 1, isCritical: false };


### PR DESCRIPTION
## Summary
- import `getTypeEffectiveness` into the damage calculator

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879bf6f18f4832ba47576e9af96d19d